### PR TITLE
Added Privacy Provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -15,17 +15,32 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Plugin privacy provider
  *
- * @package     report_ncmusergrades
- * @copyright   2018 Nicolas Jourdain <nicolas.jourdain@navitas.com>
- * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    report_ncmusergrades
+ * @author     Scott Verbeek <scottverbeek@catalyst-au.net>
+ * @copyright  2020 Catalyst AU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace report_ncmusergrades\privacy;
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'report_ncmusergrades';
-$plugin->release = '1.0.4';
-$plugin->version = 2021011100;
-$plugin->requires = 2017111300;
-$plugin->maturity = MATURITY_STABLE;
+/**
+ * Privacy provider class for package report_ncmusergrades
+ */
+class provider implements
+    // This plugin does not store any personal user data.
+    \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/report_ncmusergrades.php
+++ b/lang/en/report_ncmusergrades.php
@@ -32,6 +32,7 @@ $string['filter'] = 'Filter';
 $string['filterby'] = 'Filter by';
 $string['userid'] = 'Student ID';
 $string['rulemsguserid'] = 'The user ID is required';
+$string['privacy:metadata'] = 'The NCM User Grades plugin does not store any personal data.';
 
 $string['nolearningplanavailable'] = 'No learning plan available';
 $string['apply'] = 'Apply';
@@ -43,4 +44,3 @@ $string['nolearningplanavailable'] = 'No learning plan available';
 $string['apply'] = 'Apply';
 
 $string['ncmusergrades:use'] = 'Advisor Report Use';
-


### PR DESCRIPTION
The Privacy provider is required for Moodle 3.9. Read more about the moodle [Privacy API](https://docs.moodle.org/dev/Privacy_API) here. This is a fix to the following failing unit test.
```
There was 1 failure:

1) provider_testcase::test_all_providers_compliant with data set "report_ncmusergrades" ('report_ncmusergrades', 'report_ncmusergrades\privacy\provider')
Failed asserting that false is true.

/siteroot/privacy/tests/provider_test.php:178
/siteroot/lib/phpunit/classes/advanced_testcase.php:80

To re-run:
 vendor/bin/phpunit "provider_testcase" privacy/tests/provider_test.php
 ```